### PR TITLE
Fixed Indexing Issue Affecting Search

### DIFF
--- a/beatty_CSCI2270_Final/src/alphabet.cpp
+++ b/beatty_CSCI2270_Final/src/alphabet.cpp
@@ -103,7 +103,7 @@ void alphabet::addWord(std::string name)
 
             newLetter = addLetter(temp, name[i]);
             temp = newLetter;
-            if(i == name.length() - 1)
+            if(i == name.length() - 2)
             {
                 break;
             }


### PR DESCRIPTION
I think what was happening is that there was a non-printable new line character in the text file that the addword method picked up. It seemed to always add words that I added into the program correctly, but always had an extra character when reading from the text file. I discovered this when I had it add the text file words twice and the error was still present.